### PR TITLE
Validate recovery codes fix

### DIFF
--- a/resources/views/authenticate.blade.php
+++ b/resources/views/authenticate.blade.php
@@ -33,9 +33,10 @@
 <body class="bg-40 text-black h-full">
 <div class="h-full">
     <div class="px-view py-view mx-auto">
-        <div class="mx-auto py-8 max-w-sm text-center text-90">
-            @include('nova::partials.logo')
-        </div>
+        {{-- Disabled because of issue: https://github.com/LifeOnScreen/nova-google2fa/issues/11 --}}
+        {{--<div class="mx-auto py-8 max-w-sm text-center text-90">--}}
+            {{--@include('nova::partials.logo')--}}
+        {{--</div>--}}
 
         <form id="authenticate_form" class="bg-white shadow rounded-lg p-8 max-w-xl mx-auto" method="POST"
               action="/los/2fa/authenticate">

--- a/resources/views/recovery.blade.php
+++ b/resources/views/recovery.blade.php
@@ -20,10 +20,9 @@
         .rounded-lg {
             border-radius: 0 !important;
         }
-        @media print
-        {
-            .no-print, .no-print *
-            {
+
+        @media print {
+            .no-print, .no-print * {
                 display: none !important;
             }
         }
@@ -32,9 +31,10 @@
 <body class="bg-40 text-black h-full">
 <div class="h-full">
     <div class="px-view py-view mx-auto">
-        <div class="mx-auto py-8 max-w-sm text-center text-90">
-            @include('nova::partials.logo')
-        </div>
+        {{-- Disabled because of issue: https://github.com/LifeOnScreen/nova-google2fa/issues/11 --}}
+        {{--<div class="mx-auto py-8 max-w-sm text-center text-90">--}}
+        {{--@include('nova::partials.logo')--}}
+        {{--</div>--}}
 
         <form class="bg-white shadow rounded-lg p-8 max-w-xl mx-auto" method="POST" action="/los/2fa/register">
             <h2 class="p-2">Recovery codes</h2>

--- a/resources/views/register.blade.php
+++ b/resources/views/register.blade.php
@@ -22,19 +22,20 @@
         }
     </style>
     <script>
-        function checkAutoSubmit(el) {
-            if (el.value.length === 6) {
-                document.getElementById('register_form').submit();
-            }
-        }
+		function checkAutoSubmit(el) {
+			if (el.value.length === 6) {
+				document.getElementById('register_form').submit();
+			}
+		}
     </script>
 </head>
 <body class="bg-40 text-black h-full">
 <div class="h-full">
     <div class="px-view py-view mx-auto">
-        <div class="mx-auto py-8 max-w-sm text-center text-90">
-            @include('nova::partials.logo')
-        </div>
+        {{-- Disabled because of issue: https://github.com/LifeOnScreen/nova-google2fa/issues/11 --}}
+        {{--<div class="mx-auto py-8 max-w-sm text-center text-90">--}}
+        {{--@include('nova::partials.logo')--}}
+        {{--</div>--}}
 
         <form id="register_form" class="bg-white shadow rounded-lg p-8 max-w-xl mx-auto" method="POST"
               action="/los/2fa/confirm">

--- a/src/Google2fa.php
+++ b/src/Google2fa.php
@@ -88,7 +88,7 @@ class Google2fa extends Tool
     private function isRecoveryValid($recover, $recoveryHashes)
     {
         foreach ($recoveryHashes as $recoveryHash) {
-            if (password_verify($recover, $recoveryHash)) {
+            if ($recover === $recoveryHash) {
                 return true;
             }
         }


### PR DESCRIPTION
There was a issue with validating recovery codes.

The recovery codes are not shown to the user as hashed values but the validating part uses password_verify. This results in always false.

Original code:
```
private function isRecoveryValid($recover, $recoveryHashes)
{
    foreach ($recoveryHashes as $recoveryHash) {
        if (password_verify($recover, $recoveryHash)) {
            return true;
        }
    }

    return false;
}
```

The fix:
```
private function isRecoveryValid($recover, $recoveryHashes)
{
    foreach ($recoveryHashes as $recoveryHash) {
        if ($recover === $recoveryHash) {
            return true;
        }
    }

    return false;
}
```