### PR TITLE
Task/RHCAVAPI-470 Adding setting to make use optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * [1.1.3](#400---2021-04-13) - Fixes tag issue
 * [1.1.4](#400---2021-04-14) - Updates views
 * [1.1.5](#400---2021-04-23) - Fixes bug in google 2fa middleware cache prevention
-* [1.1.6](#400---2021-04-23) - Updates release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     * PATCH version when you make backwards-compatible bug fixes.
 
 ## Major Versions
-* [1.1.0](#400---2021-04-13) - Adds support for PHP 8
+* [1.1.1](#400---2021-04-13) - Adds support for PHP 8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * [1.1.1](#400---2021-04-13) - Adds support for PHP 8
 * [1.1.2](#400---2021-04-13) - Excludes logout from 2fa middleware
 * [1.1.3](#400---2021-04-13) - Fixes tag issue
+* [1.1.4](#400---2021-04-14) - Updates views
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Major Versions
 * [1.1.1](#400---2021-04-13) - Adds support for PHP 8
 * [1.1.2](#400---2021-04-13) - Excludes logout from 2fa middleware
+* [1.1.3](#400---2021-04-13) - Fixes tag issue
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+    Given a version number MAJOR.MINOR.PATCH, increment the:
+
+    * MAJOR version when you make incompatible API changes,
+    * MINOR version when you add functionality in a backwards-compatible manner, and
+    * PATCH version when you make backwards-compatible bug fixes.
+
+## Major Versions
+* [1.1.0](#400---2021-04-13) - Adds support for PHP 8
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Major Versions
 * [1.1.1](#400---2021-04-13) - Adds support for PHP 8
+* [1.1.2](#400---2021-04-13) - Excludes logout from 2fa middleware
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,4 +15,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * [1.1.2](#400---2021-04-13) - Excludes logout from 2fa middleware
 * [1.1.3](#400---2021-04-13) - Fixes tag issue
 * [1.1.4](#400---2021-04-14) - Updates views
+* [1.1.5](#400---2021-04-23) - Fixes bug in google 2fa middleware cache prevention
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * [1.1.3](#400---2021-04-13) - Fixes tag issue
 * [1.1.4](#400---2021-04-14) - Updates views
 * [1.1.5](#400---2021-04-23) - Fixes bug in google 2fa middleware cache prevention
+* [1.1.6](#400---2021-04-23) - Updates release
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ This package enforces 2FA for Laravel Nova.
 
 - User is redirected to activation process.
 
+- Optional use
+
+If the `GOOGLE_2FA_OPTIONAL` environment parameter is set to true, 2fa will only be used if the user has configured their account to use it. In this case, you should provide a link to `'/los/2fa/recovery'` to allow the user to enable 2fa.
+
 ## Installation
 
 Install via composer
@@ -109,6 +113,16 @@ return [
      * Disable or enable middleware.
      */
     'enabled' => env('GOOGLE_2FA_ENABLED', true),
+    
+    /**
+     * Use only if user has configured to do so
+     */
+    'optional' => env('GOOGLE_2FA_OPTIONAL', false),
+
+    /**
+     * Display the secret code as an alternative to using the QR code
+     */
+    'display_secret_code' => env('GOOGLE_DISPLAY_SECRET_CODE', false),
 
     'models' => [
         /**

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-## LifeOnScreen/nova-google2fa
+## netsells/nova-google2fa
 
 This package enforces 2FA for Laravel Nova.
-
-## Upgrade from 0.0.7 to 1.0.0
-
-Upgrade guide is available [Here](docs/upgrade_to_1.0.0.md').
 
 ## Flow
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Upgrade guide is available [Here](docs/upgrade_to_1.0.0.md').
 Install via composer
 
 ``` bash
-$ composer require lifeonscreen/nova-google2fa
+$ composer require netsells/nova-google2fa
 ```
 
 Publish config and migrations

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ public function user2fa(): HasOne
 }
 ```
 
-Add middleware to `nova.config`.
+Add middleware to `config/nova`.
 ```php
 [
     ...

--- a/README.md
+++ b/README.md
@@ -171,3 +171,5 @@ MIT license. Please see the [license file](docs/license.md) for more information
 [link-packagist]: https://packagist.org/packages/lifeonscreen/nova-google2fa
 [link-downloads]: https://packagist.org/packages/lifeonscreen/nova-google2fa
 [link-author]: https://github.com/LifeOnScreen
+
+Fork created and maintained by the [Netsells team](https://netsells.co.uk/)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This package enforces 2FA for Laravel Nova.
 
+## Dependencies
+* PHP 7.4 or higher
+* Imagik
+
 ## Flow
 
 ### Activation

--- a/README.md
+++ b/README.md
@@ -44,7 +44,25 @@ Install via composer
 $ composer require netsells/nova-google2fa
 ```
 
-Publish config and migrations
+Publish config
+
+``` bash
+$ php artisan vendor:publish --provider="Lifeonscreen\Google2fa\ToolServiceProvider" --tag=lifeonscreen2fa.config
+```
+
+Publish migrations
+
+``` bash
+$ php artisan vendor:publish --provider="Lifeonscreen\Google2fa\ToolServiceProvider" --tag=migrations
+```
+
+Publish views (optional)
+
+``` bash
+$ php artisan vendor:publish --provider="Lifeonscreen\Google2fa\ToolServiceProvider" --tag=views
+```
+
+Or publish all in one go (optional)
 
 ``` bash
 $ php artisan vendor:publish --provider="Lifeonscreen\Google2fa\ToolServiceProvider"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "netsells/nova-google2fa",
     "description": "This package provides Google2FA to Laravel Nova.",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "keywords": [
         "laravel",
         "nova"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "lifeonscreen/nova-google2fa",
+    "name": "netsells/nova-google2fa",
     "description": "This package provides Google2FA to Laravel Nova.",
     "keywords": [
         "laravel",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "netsells/nova-google2fa",
     "description": "This package provides Google2FA to Laravel Nova.",
-    "version": "1.1.0",
+    "version": "1.1.2",
     "keywords": [
         "laravel",
         "nova"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "netsells/nova-google2fa",
     "description": "This package provides Google2FA to Laravel Nova.",
+    "version": "1.0.2",
     "keywords": [
         "laravel",
         "nova"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "netsells/nova-google2fa",
     "description": "This package provides Google2FA to Laravel Nova.",
-    "version": "1.1.4",
+    "version": "1.1.6",
     "keywords": [
         "laravel",
         "nova"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "netsells/nova-google2fa",
     "description": "This package provides Google2FA to Laravel Nova.",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "keywords": [
         "laravel",
         "nova"

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
     "require": {
         "php": ">=7.1.0",
         "bacon/bacon-qr-code": "^2.0",
-        "pragmarx/google2fa-laravel": "^0.2.0",
-        "netsells/recovery": "dev-master"
+        "pragmarx/google2fa-laravel": "v1.4.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,17 @@
         "nova"
     ],
     "license": "MIT",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../projects/recovery"
+        }
+    ],
     "require": {
         "php": ">=7.1.0",
         "bacon/bacon-qr-code": "^2.0",
-        "pragmarx/recovery": "^0.1.0",
-        "pragmarx/google2fa-laravel": "^0.2.0"
+        "pragmarx/google2fa-laravel": "^0.2.0",
+        "netsells/recovery": "dev-master"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "netsells/nova-google2fa",
     "description": "This package provides Google2FA to Laravel Nova.",
-    "version": "1.0.3",
+    "version": "1.1.0",
     "keywords": [
         "laravel",
         "nova"
@@ -14,11 +14,11 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.4",
         "bacon/bacon-qr-code": "^2.0",
         "netsells/recovery": "1.0.0",
-        "pragmarx/google2fa-laravel": "^0.2.0",
-        "pragmarx/google2fa-qrcode": "^2.1"
+        "pragmarx/google2fa-laravel": "^1.4.0",
+        "pragmarx/google2fa-qrcode": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "netsells/nova-google2fa",
     "description": "This package provides Google2FA to Laravel Nova.",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "keywords": [
         "laravel",
         "nova"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
     "require": {
         "php": ">=7.1.0",
         "bacon/bacon-qr-code": "^2.0",
-        "pragmarx/google2fa-laravel": "v1.4.1"
+        "netsells/recovery": "1.0.0",
+        "pragmarx/google2fa-laravel": "^0.2.0",
+        "pragmarx/google2fa-qrcode": "^2.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "netsells/nova-google2fa",
     "description": "This package provides Google2FA to Laravel Nova.",
-    "version": "1.1.6",
+    "version": "1.1.5",
     "keywords": [
         "laravel",
         "nova"

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     "license": "MIT",
     "repositories": [
         {
-            "type": "path",
-            "url": "../../projects/recovery"
+            "type": "git",
+            "url": "https://github.com/netsells/recovery.git"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": ">=7.4",
+        "ext-imagick": "*",
         "bacon/bacon-qr-code": "^2.0",
         "netsells/recovery": "1.0.0",
         "pragmarx/google2fa-laravel": "^1.4.0",

--- a/config/lifeonscreen2fa.php
+++ b/config/lifeonscreen2fa.php
@@ -9,6 +9,16 @@ return [
     'enabled' => env('GOOGLE_2FA_ENABLED', true),
 
     /**
+     * Use only if user has configured to do so
+     */
+    'optional' => env('GOOGLE_2FA_OPTIONAL', false),
+
+    /**
+     * Display the secret code as an alternative to using the QR code
+     */
+    'display_secret_code' => env('GOOGLE_DISPLAY_SECRET_CODE', false),
+
+    /**
      * Apply 2FA auth only on users whose email ends with this domain
      */
     'user_email_domain' => env('GOOGLE_2FA_USER_EMAIL_DOMAIN', ''),

--- a/config/lifeonscreen2fa.php
+++ b/config/lifeonscreen2fa.php
@@ -8,6 +8,11 @@ return [
      */
     'enabled' => env('GOOGLE_2FA_ENABLED', true),
 
+    /**
+     * Apply 2FA auth only on users whose email ends with this domain
+     */
+    'user_email_domain' => env('GOOGLE_2FA_USER_EMAIL_DOMAIN', ''),
+
     'models' => [
         /**
          * Change this variable to path to user model.

--- a/database/migrations/2018_10_15_095425_create_user_2fa_table.php
+++ b/database/migrations/2018_10_15_095425_create_user_2fa_table.php
@@ -15,15 +15,11 @@ class CreateUser2faTable extends Migration
     {
         Schema::create('user_2fa', function (Blueprint $table) {
             $table->increments('id');
-            $table->unsignedInteger('user_id');
+            $table->foreignId('user_id');
             $table->boolean('google2fa_enable')->default(false);
             $table->string('google2fa_secret')->nullable();
             $table->text('recovery')->nullable();
             $table->timestamps();
-
-            $table->foreign('user_id')
-                ->references('id')
-                ->on(config('lifeonscreen2fa.tables.user'));
         });
     }
 

--- a/resources/css/nova-google2fa.css
+++ b/resources/css/nova-google2fa.css
@@ -1,0 +1,16 @@
+body {
+    font-family: "Montserrat", sans-serif !important;
+}
+
+.btn,
+.form-input,
+.rounded-lg {
+    border-radius: 0 !important;
+}
+@media print
+{
+    .no-print, .no-print *
+    {
+        display: none !important;
+    }
+}

--- a/resources/js/nova-google2fa.js
+++ b/resources/js/nova-google2fa.js
@@ -1,0 +1,40 @@
+function checkAutoSubmit(el) {
+    if (el.value.length === 6) {
+        document.getElementById('authenticate_form').submit();
+    }
+}
+
+var callback = function(){
+    // Handler when the DOM is fully loaded
+
+    var secretInput = document.getElementById('secret');
+    if (secretInput) {
+        checkAutoSubmit(secretInput);
+    }
+
+    var recoverButton = document.getElementById("recoverButton");
+    if (recoverButton) {
+        recoverButton.addEventListener("click", function (el) {
+            document.getElementById('secret_div').style.display = 'none';
+            document.getElementById('error_text').style.display = 'none';
+            document.getElementById('recover_div').style.display = 'block';
+        });
+    }
+
+    var printButton = document.getElementById('printButton');
+    if (printButton) {
+        printButton.addEventListener('click', function(el) {
+            window.print();
+            return false;
+        })
+    }
+};
+
+if (
+    document.readyState === "complete" ||
+    (document.readyState !== "loading" && !document.documentElement.doScroll)
+) {
+    callback();
+} else {
+    document.addEventListener("DOMContentLoaded", callback);
+}

--- a/resources/views/authenticate.blade.php
+++ b/resources/views/authenticate.blade.php
@@ -33,9 +33,10 @@
 <body class="bg-40 text-black h-full">
 <div class="h-full">
     <div class="px-view py-view mx-auto">
-        <div class="mx-auto py-8 max-w-sm text-center text-90">
+        <div class="mx-auto py-8 max-w-sm text-center text-90 bg-logo">
             @include('nova::partials.logo')
         </div>
+        <br>
 
         <form id="authenticate_form" class="bg-white shadow rounded-lg p-8 max-w-xl mx-auto" method="POST"
               action="/los/2fa/authenticate">

--- a/resources/views/authenticate.blade.php
+++ b/resources/views/authenticate.blade.php
@@ -1,89 +1,58 @@
-<!DOCTYPE html>
-<html lang="en" class="h-full font-sans">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="csrf-token" content="{{ csrf_token() }}">
+@extends('vendor.google2fa.partials.layout')
 
-    <title>{{ Nova::name() }}</title>
-
-    <!-- Styles -->
-    <link rel="stylesheet" href="{{ mix('app.css', 'vendor/nova') }}">
-
-    <style>
-        body {
-            font-family: "Montserrat", sans-serif !important;
-        }
-
-        .btn,
-        .form-input,
-        .rounded-lg {
-            border-radius: 0 !important;
-        }
-    </style>
+@section('scripts')
     <script>
         function checkAutoSubmit(el) {
             if (el.value.length === 6) {
                 document.getElementById('authenticate_form').submit();
             }
         }
-
     </script>
-</head>
-<body class="bg-40 text-black h-full">
-<div class="h-full">
-    <div class="px-view py-view mx-auto">
-        <div class="mx-auto py-8 max-w-sm text-center text-90 bg-logo">
-            @include('nova::partials.logo')
-        </div>
-        <br>
+@endsection
 
-        <form id="authenticate_form" class="bg-white shadow rounded-lg p-8 max-w-xl mx-auto" method="POST"
-              action="/los/2fa/authenticate">
-            @csrf
-            <h2 class="p-2">Two Factor Authentication</h2>
+@section('content')
+    @include('nova::auth.partials.header')
+    <form id="authenticate_form" class="bg-white shadow rounded-lg p-8 max-w-login mx-auto" method="POST"
+            action="/los/2fa/authenticate">
+        @csrf
+        @component('nova::auth.partials.heading')
+            {{ __('Two Factor Authentication') }}
+        @endcomponent
+        <p class="p-2"><strong>Enter the pin from Google Authenticator</strong></p>
 
-            <p class="p-2">Two factor authentication (2FA) strengthens access security by requiring two methods (also
-                referred to as factors) to
-                verify your identity.
-                Two factor authentication protects against phishing, social engineering and password brute force attacks
-                and secures your logins from attackers
-                exploiting weak or stolen credentials.</p>
-            <p class="p-2"><strong>Enter the pin from Google Authenticator Enable 2FA</strong></p>
-
-            <div class="text-center pt-3">
-                <div class="mb-6 w-1/2" style="display:inline-block">
-                    @if (isset($error))
-                        <p id="error_text" class="text-center font-semibold text-danger my-3">
-                            {{  $error }}
-                            <button
-                                    onclick="
-                                        document.getElementById('secret_div').style.display = 'none';
-                                        document.getElementById('error_text').style.display = 'none';
-                                        document.getElementById('recover_div').style.display = 'block';
-                                    "
-                                    class="w-1/4 btn btn-default btn-primary hover:bg-primary-dark" type="button">
-                                Recover
-                            </button>
-                        </p>
-                    @endif
-                    <div id="secret_div">
-                        <label class="block font-bold mb-2" for="co">One Time Password</label>
-                        <input class="form-control form-input form-input-bordered w-full" id="secret" type="number"
-                               name="secret" value="" onkeyup="checkAutoSubmit(this)" autofocus="">
-                    </div>
-                    <div id="recover_div" style="display: none;">
-                        <label class="block font-bold mb-2" for="co">Recovery code</label>
-                        <input class="form-control form-input form-input-bordered w-full" id="recover" type="text"
-                               name="recover" value="" autofocus="">
-                    </div>
+        <div class="text-center pt-3">
+            <div class="mb-6 w-1/2" style="display:inline-block">
+                @if (isset($error))
+                    <p id="error_text" class="text-center font-semibold text-danger my-3">
+                        {{  $error }}<br>
+                        <button
+                                onclick="
+                                    document.getElementById('secret_div').style.display = 'none';
+                                    document.getElementById('error_text').style.display = 'none';
+                                    document.getElementById('recover_div').style.display = 'block';
+                                "
+                                class="btn btn-default btn-primary hover:bg-primary-dark" type="button">
+                            Recover
+                        </button>
+                    </p>
+                @endif
+                <div id="secret_div">
+                    <label class="block font-bold mb-2" for="co">One Time Password</label>
+                    <input class="form-control form-input form-input-bordered w-full" id="secret" type="text"
+                            name="secret" value="" onkeyup="checkAutoSubmit(this)" autofocus="">
                 </div>
-                <button class="w-1/2 btn btn-default btn-primary hover:bg-primary-dark" type="submit">
-                    Authenticate
-                </button>
+                <div id="recover_div" style="display: none;">
+                    <label class="block font-bold mb-2" for="co">Recovery code</label>
+                    <input class="form-control form-input form-input-bordered w-full" id="recover" type="text"
+                            name="recover" value="" autofocus="">
+                </div>
             </div>
-        </form>
-    </div>
-</div>
-</body>
-</html>
+            <button class="w-1/2 btn btn-default btn-primary hover:bg-primary-dark" type="submit">
+                Authenticate
+            </button><br><br>
+            <a href="{{ route('nova.logout') }}">
+                {{ __('Back to Login') }}
+            </a>
+        </div>
+    </form>
+@endsection

--- a/resources/views/partials/layout.blade.php
+++ b/resources/views/partials/layout.blade.php
@@ -31,4 +31,19 @@
         </div>
     </div>
 </body>
+@isset ($displaySecretCode)
+    @if ($displaySecretCode)
+    <script type="application/javascript">
+        function copyCode()
+        {
+            let code = document.getElementById('secret_code');
+
+            code.select();
+            code.setSelectionRange(0, 99999);
+
+            document.execCommand('copy');
+        }
+    </script>
+    @endif
+@endisset
 </html>

--- a/resources/views/partials/layout.blade.php
+++ b/resources/views/partials/layout.blade.php
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="h-full font-sans antialiased">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+
+    <title>{{ \Laravel\Nova\Nova::name() }}</title>
+
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,800,800i,900,900i" rel="stylesheet">
+
+    <!-- Styles -->
+    <link rel="stylesheet" href="{{ mix('app.css', 'vendor/nova') }}">
+
+    <!-- Scripts -->
+    @yield('scripts')
+
+    <!-- Custom Meta Data -->
+    @include('nova::partials.meta')
+
+    <!-- Theme Styles -->
+    @foreach(\Laravel\Nova\Nova::themeStyles() as $publicPath)
+        <link rel="stylesheet" href="{{ $publicPath }}">
+    @endforeach
+</head>
+<body class="bg-40 text-black h-full">
+    <div class="h-full">
+        <div class="px-view py-view mx-auto">
+            @yield('content')
+        </div>
+    </div>
+</body>
+</html>

--- a/resources/views/recovery.blade.php
+++ b/resources/views/recovery.blade.php
@@ -1,76 +1,47 @@
-<!DOCTYPE html>
-<html lang="en" class="h-full font-sans">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="csrf-token" content="{{ csrf_token() }}">
 
-    <title>{{ Nova::name() }}</title>
+@extends('vendor.google2fa.partials.layout')
 
-    <!-- Styles -->
-    <link rel="stylesheet" href="{{ mix('app.css', 'vendor/nova') }}">
-
-    <style>
-        body {
-            font-family: "Montserrat", sans-serif !important;
-        }
-
-        .btn,
-        .form-input,
-        .rounded-lg {
-            border-radius: 0 !important;
-        }
-        @media print
-        {
-            .no-print, .no-print *
-            {
-                display: none !important;
-            }
-        }
-    </style>
-</head>
-<body class="bg-40 text-black h-full">
-<div class="h-full">
-    <div class="px-view py-view mx-auto">
-        <div class="mx-auto py-8 max-w-sm text-center text-90 bg-logo">
-            @include('nova::partials.logo')
-        </div>
-        <br>
-
+@section('content')
+    @include('nova::auth.partials.header')
         <form class="bg-white shadow rounded-lg p-8 max-w-xl mx-auto" method="POST" action="/los/2fa/register">
-            <h2 class="p-2">Recovery codes</h2>
+            @component('nova::auth.partials.heading')
+                {{ __('Recovery Codes') }}
+            @endcomponent
+
             @csrf
-            <p class="p-2">
-                Recovery codes are used to access your account in the event you cannot recive two-factor
-                authentication codes.
-            </p>
-            <p class="p-2 no-print">
-                <strong>
-                    Download, print or copy your codes before continuing two-factor authentication setup.
-                </strong>
-            </p>
-            <div class="p-3">
-                <label class="block font-bold mb-2" for="co">Recovery codes
-                    <button class="no-print m-1  btn btn-default btn-primary hover:bg-primary-dark" type="button"
-                            onclick="window.print();return false;">
-                        Print
-                    </button>
-                </label>
+            <div class="text-center">
+                <p class="p-2">
+                    Recovery codes are used to access your account in the event you cannot recive two-factor
+                    authentication codes.
+                </p>
+                <p class="p-2 no-print">
+                    <strong>
+                        Download, print or copy your codes before continuing two-factor authentication setup.
+                    </strong>
+                </p>
+                <div class="p-3">
+                    <label class="block font-bold mb-2" for="co">Recovery codes
+                        <button class="no-print m-1  btn btn-default btn-primary hover:bg-primary-dark" type="button"
+                                onclick="window.print();return false;">
+                            Print
+                        </button>
+                    </label>
 
-                <div>
-                    @foreach ($recovery as $recoveryCode)
-                        <ul>
-                            <li class="p-2">{{ $recoveryCode }}</li>
-                        </ul>
-                    @endforeach
+                    <div>
+                        @foreach ($recovery as $recoveryCode)
+                                <div class="p-2">{{ $recoveryCode }}</div>
+                        @endforeach
+                    </div>
                 </div>
-            </div>
 
-            <button class="no-print m-2 w-1/2 btn btn-default btn-primary hover:bg-primary-dark" type="submit">
-                Continue
-            </button>
+                <button class="no-print m-2 w-1/2 btn btn-default btn-primary hover:bg-primary-dark" type="submit">
+                    Continue
+                </button><br><br>
+                <a href="{{ route('nova.logout') }}">
+                    {{ __('Back to Login') }}
+                </a>
+            </div>
         </form>
     </div>
 </div>
-</body>
-</html>
+@endsection

--- a/resources/views/recovery.blade.php
+++ b/resources/views/recovery.blade.php
@@ -32,9 +32,10 @@
 <body class="bg-40 text-black h-full">
 <div class="h-full">
     <div class="px-view py-view mx-auto">
-        <div class="mx-auto py-8 max-w-sm text-center text-90">
+        <div class="mx-auto py-8 max-w-sm text-center text-90 bg-logo">
             @include('nova::partials.logo')
         </div>
+        <br>
 
         <form class="bg-white shadow rounded-lg p-8 max-w-xl mx-auto" method="POST" action="/los/2fa/register">
             <h2 class="p-2">Recovery codes</h2>

--- a/resources/views/register.blade.php
+++ b/resources/views/register.blade.php
@@ -18,6 +18,17 @@
             </div>
 
             <div class="text-center">
+                @if ($displaySecretCode)
+                    <div class="mb-6" style="display:inline-block">
+                        Alternatively you can type the secret key.
+                        <br>
+                        <input id="secret_code" style="background-color:lightyellow;" value ="{{ $secret_code }}"/>
+                        <svg aria-hidden="true" viewBox="0 0 16 16" version="1.1" height="16" width="16" onclick="copyCode()">
+                            <title id="copySecretTitle">Copy</title>
+                            <path fill-rule="evenodd" d="M5.75 1a.75.75 0 00-.75.75v3c0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75v-3a.75.75 0 00-.75-.75h-4.5zm.75 3V2.5h3V4h-3zm-2.874-.467a.75.75 0 00-.752-1.298A1.75 1.75 0 002 3.75v9.5c0 .966.784 1.75 1.75 1.75h8.5A1.75 1.75 0 0014 13.25v-9.5a1.75 1.75 0 00-.874-1.515.75.75 0 10-.752 1.298.25.25 0 01.126.217v9.5a.25.25 0 01-.25.25h-8.5a.25.25 0 01-.25-.25v-9.5a.25.25 0 01.126-.217z"></path>
+                        </svg>
+                    </div>
+                @endif
                 <div class="mb-6 w-1/2" style="display:inline-block">
                     @if (isset($error))
                         <p class="text-center font-semibold text-danger my-3">

--- a/resources/views/register.blade.php
+++ b/resources/views/register.blade.php
@@ -9,25 +9,10 @@
 
     <!-- Styles -->
     <link rel="stylesheet" href="{{ mix('app.css', 'vendor/nova') }}">
+    <link rel="stylesheet" type="text/css" href="{{ asset('vendor/nova-google2fa/nova-google2fa.css') }}">
 
-    <style>
-        body {
-            font-family: "Montserrat", sans-serif !important;
-        }
-
-        .btn,
-        .form-input,
-        .rounded-lg {
-            border-radius: 0 !important;
-        }
-    </style>
-    <script>
-        function checkAutoSubmit(el) {
-            if (el.value.length === 6) {
-                document.getElementById('register_form').submit();
-            }
-        }
-    </script>
+    <!-- JS -->
+    <script type="application/javascript" src="{{ asset('vendor/nova-google2fa/nova-google2fa.js') }}"></script>
 </head>
 <body class="bg-40 text-black h-full">
 <div class="h-full">
@@ -37,7 +22,7 @@
         </div>
 
         <form id="register_form" class="bg-white shadow rounded-lg p-8 max-w-xl mx-auto" method="POST"
-              action="/los/2fa/confirm">
+              action="confirm">
             @csrf
             <h2 class="p-2">Two Factor Authentication</h2>
 
@@ -53,7 +38,7 @@
                 </ol>
             </strong>
             <div class="text-center">
-                <img src="{{ $google2fa_url }}" alt="">
+                <img src="{{ $qrcode_image }}" alt="">
             </div>
 
             <div class="text-center">
@@ -65,7 +50,7 @@
                     @endif
                     <label class="block font-bold mb-2" for="co">Secret</label>
                     <input class="form-control form-input form-input-bordered w-full" id="secret" type="number"
-                           name="secret" value="" required="required" onkeyup="checkAutoSubmit(this)" autofocus="">
+                           name="secret" value="" required="required" autofocus="">
                 </div>
                 <button class="w-1/2 btn btn-default btn-primary hover:bg-primary-dark" type="submit">
                     Confirm

--- a/resources/views/register.blade.php
+++ b/resources/views/register.blade.php
@@ -1,42 +1,17 @@
-<!DOCTYPE html>
-<html lang="en" class="h-full font-sans">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="csrf-token" content="{{ csrf_token() }}">
+@extends('vendor.google2fa.partials.layout')
 
-    <title>{{ Nova::name() }}</title>
-
-    <!-- Styles -->
-    <link rel="stylesheet" href="{{ mix('app.css', 'vendor/nova') }}">
-    <link rel="stylesheet" type="text/css" href="{{ asset('vendor/nova-google2fa/nova-google2fa.css') }}">
-
-    <!-- JS -->
-    <script type="application/javascript" src="{{ asset('vendor/nova-google2fa/nova-google2fa.js') }}"></script>
-</head>
-<body class="bg-40 text-black h-full">
-<div class="h-full">
-    <div class="px-view py-view mx-auto">
-        <div class="mx-auto py-8 max-w-sm text-center text-90 bg-logo">
-            @include('nova::partials.logo')
-        </div>
-        <br>
-
-        <form id="register_form" class="bg-white shadow rounded-lg p-8 max-w-xl mx-auto" method="POST"
+@section('content')
+    @include('nova::auth.partials.header')
+        <form id="register_form" class="bg-white shadow rounded-lg p-8 max-w-login mx-auto" method="POST"
               action="confirm">
             @csrf
-            <h2 class="p-2">Two Factor Authentication</h2>
-
-            <p class="p-2">Two factor authentication (2FA) strengthens access security by requiring two methods (also
-                referred
-                to as factors) to verify your identity. Two factor authentication protects against phishing, social
-                engineering and password brute force attacks and secures your logins from attackers exploiting weak
-                or stolen credentials.</p>
-            <p class="p-2">To Enable Two Factor Authentication on your Account, you need to do following steps</p>
+            @component('nova::auth.partials.heading')
+                {{ __('Add to Google Authenticator') }}
+            @endcomponent
             <strong>
-                <ol>
-                    <li>Verify the OTP from Google Authenticator Mobile App</li>
-                </ol>
+                <div class="text-center">
+                    Scan the Barcode From Your Google Authenticator Mobile App
+                </div>
             </strong>
             <div class="text-center">
                 <img src="{{ $qrcode_image }}" alt="">
@@ -50,15 +25,17 @@
                         </p>
                     @endif
                     <label class="block font-bold mb-2" for="co">Secret</label>
-                    <input class="form-control form-input form-input-bordered w-full" id="secret" type="number"
+                    <input class="form-control form-input form-input-bordered w-full" id="secret" type="text"
                            name="secret" value="" required="required" autofocus="">
                 </div>
-                <button class="w-1/2 btn btn-default btn-primary hover:bg-primary-dark" type="submit">
+                <button class="no-print m-2 w-1/2 btn btn-default btn-primary hover:bg-primary-dark" type="submit">
                     Confirm
-                </button>
+                </button><br><br>
+                <a href="{{ route('nova.logout') }}">
+                    {{ __('Back to Login') }}
+                </a>
             </div>
         </form>
     </div>
 </div>
-</body>
-</html>
+@endsection

--- a/resources/views/register.blade.php
+++ b/resources/views/register.blade.php
@@ -17,9 +17,10 @@
 <body class="bg-40 text-black h-full">
 <div class="h-full">
     <div class="px-view py-view mx-auto">
-        <div class="mx-auto py-8 max-w-sm text-center text-90">
+        <div class="mx-auto py-8 max-w-sm text-center text-90 bg-logo">
             @include('nova::partials.logo')
         </div>
+        <br>
 
         <form id="register_form" class="bg-white shadow rounded-lg p-8 max-w-xl mx-auto" method="POST"
               action="confirm">

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,5 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('recovery', 'Lifeonscreen\Google2fa\Google2fa@showRecoveryView');

--- a/src/Google2fa.php
+++ b/src/Google2fa.php
@@ -68,6 +68,8 @@ class Google2fa extends Tool
         }
 
         $data['qrcode_image'] = $this->getQRCode();
+        $data['secret_code'] = auth()->user()->user2fa->google2fa_secret;
+        $data['displaySecretCode'] = config('lifeonscreen2fa.display_secret_code');
         $data['error'] = 'Secret is invalid.';
 
         return view('google2fa::register', $data);
@@ -80,6 +82,8 @@ class Google2fa extends Tool
     public function register()
     {
         $data['qrcode_image'] = $this->getQRCode();
+        $data['secret_code'] = auth()->user()->user2fa->google2fa_secret;
+        $data['displaySecretCode'] = config('lifeonscreen2fa.display_secret_code');
 
         return view('google2fa::register', $data);
     }

--- a/src/Google2fa.php
+++ b/src/Google2fa.php
@@ -61,8 +61,8 @@ class Google2fa extends Tool
         if ($this->is2FAValid()) {
             auth()->user()->user2fa->google2fa_enable = 1;
             auth()->user()->user2fa->save();
-            $authenticator = app(Google2FAAuthenticator::class);
-            $authenticator->login();
+
+            app(Google2FAAuthenticator::class)->login();
 
             return response()->redirectTo(config('nova.path'));
         }

--- a/src/Google2fa.php
+++ b/src/Google2fa.php
@@ -87,7 +87,7 @@ class Google2fa extends Tool
     private function isRecoveryValid($recover, $recoveryHashes)
     {
         foreach ($recoveryHashes as $recoveryHash) {
-            if (password_verify($recover, $recoveryHash)) {
+            if ($recover === $recoveryHash) {
                 return true;
             }
         }
@@ -138,7 +138,7 @@ class Google2fa extends Tool
         $user2fa = new $user2faModel();
         $user2fa->user_id = auth()->user()->id;
         $user2fa->google2fa_secret = $secretKey;
-        $user2fa->recovery = json_encode($user2fa->hashRecoveryCodes($data['recovery']));
+        $user2fa->recovery = json_encode($data['recovery']);
         $user2fa->save();
 
         return response(view('google2fa::recovery', $data));

--- a/src/Google2fa.php
+++ b/src/Google2fa.php
@@ -2,8 +2,12 @@
 
 namespace Lifeonscreen\Google2fa;
 
+use BaconQrCode\Renderer\Image\ImagickImageBackEnd;
+use BaconQrCode\Renderer\ImageRenderer;
+use BaconQrCode\Renderer\RendererStyle\RendererStyle;
+use BaconQrCode\Writer;
 use Laravel\Nova\Tool;
-use PragmaRX\Google2FA\Google2FA as G2fa;
+use PragmaRX\Google2FAQRCode\Google2FA as G2fa;
 use PragmaRX\Recovery\Recovery;
 use Request;
 
@@ -19,28 +23,51 @@ class Google2fa extends Tool
     }
 
     /**
+     * @return bool
+     */
+    protected function is2FAValid()
+    {
+        $secret = Request::get('secret');
+        if (empty($secret)) {
+            return false;
+        }
+
+        $google2fa = new G2fa();
+
+        return $google2fa->verifyKey(auth()->user()->user2fa->google2fa_secret, $secret);
+    }
+
+    protected function getQRCode()
+    {
+        $google2fa = new G2fa();
+
+        $google2fa_url = $google2fa->getQRCodeInline(
+            config('lifeonscreen2fa.company'),
+            auth()->user()->email,
+            auth()->user()->user2fa->google2fa_secret
+        );
+
+        return $google2fa_url;
+
+//        return base64_encode($writer->writeString($google2fa_url));
+    }
+
+    /**
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\Http\RedirectResponse|\Illuminate\View\View
      * @throws \PragmaRX\Google2FA\Exceptions\InsecureCallException
      */
     public function confirm()
     {
-        if (app(Google2FAAuthenticator::class)->isAuthenticated()) {
+        if ($this->is2FAValid()) {
             auth()->user()->user2fa->google2fa_enable = 1;
             auth()->user()->user2fa->save();
+            $authenticator = app(Google2FAAuthenticator::class);
+            $authenticator->login();
 
             return response()->redirectTo(config('nova.path'));
         }
 
-        $google2fa = new G2fa();
-        $google2fa->setAllowInsecureCallToGoogleApis(true);
-
-        $google2fa_url = $google2fa->getQRCodeGoogleUrl(
-            config('app.name'),
-            auth()->user()->email,
-            auth()->user()->user2fa->google2fa_secret
-        );
-
-        $data['google2fa_url'] = $google2fa_url;
+        $data['qrcode_image'] = $this->getQRCode();
         $data['error'] = 'Secret is invalid.';
 
         return view('google2fa::register', $data);
@@ -52,19 +79,9 @@ class Google2fa extends Tool
      */
     public function register()
     {
-        $google2fa = new G2fa();
-        $google2fa->setAllowInsecureCallToGoogleApis(true);
-
-        $google2fa_url = $google2fa->getQRCodeGoogleUrl(
-            config('app.name'),
-            auth()->user()->email,
-            auth()->user()->user2fa->google2fa_secret
-        );
-
-        $data['google2fa_url'] = $google2fa_url;
+        $data['qrcode_image'] = $this->getQRCode();
 
         return view('google2fa::register', $data);
-
     }
 
     private function isRecoveryValid($recover, $recoveryHashes)
@@ -83,6 +100,7 @@ class Google2fa extends Tool
      */
     public function authenticate()
     {
+        $data = [];
         if ($recover = Request::get('recover')) {
             if ($this->isRecoveryValid($recover, json_decode(auth()->user()->user2fa->recovery, true)) === false) {
                 $data['error'] = 'Recovery key is invalid.';
@@ -90,38 +108,39 @@ class Google2fa extends Tool
                 return view('google2fa::authenticate', $data);
             }
 
-            $google2fa = new G2fa();
-            $recovery = new Recovery();
-            $secretKey = $google2fa->generateSecretKey();
-            $data['recovery'] = $recovery
-                ->setCount(config('lifeonscreen2fa.recovery_codes.count'))
-                ->setBlocks(config('lifeonscreen2fa.recovery_codes.blocks'))
-                ->setChars(config('lifeonscreen2fa.recovery_codes.chars_in_block'))
-                ->toArray();
-
-            $recoveryHashes = $data['recovery'];
-            array_walk($recoveryHashes, function (&$value) {
-                $value = password_hash($value, config('lifeonscreen2fa.recovery_codes.hashing_algorithm'));
-            });
-
-            $user2faModel = config('lifeonscreen2fa.models.user2fa');
-
-            $user2faModel::where('user_id', auth()->user()->id)->delete();
-            $user2fa = new $user2faModel();
-            $user2fa->user_id = auth()->user()->id;
-            $user2fa->google2fa_secret = $secretKey;
-            $user2fa->recovery = json_encode($recoveryHashes);
-            $user2fa->save();
-
-            return response(view('google2fa::recovery', $data));
+            return $this->showRecoveryView($data);
         }
+        if ($this->is2FAValid()) {
+            $authenticator = app(Google2FAAuthenticator::class);
+            $authenticator->login();
 
-        if (app(Google2FAAuthenticator::class)->isAuthenticated()) {
             return response()->redirectTo(config('nova.path'));
         }
-
         $data['error'] = 'One time password is invalid.';
 
         return view('google2fa::authenticate', $data);
+    }
+
+    public function showRecoveryView($data = [])
+    {
+        $google2fa = new G2fa();
+        $recovery = new Recovery();
+        $secretKey = $google2fa->generateSecretKey();
+        $data['recovery'] = $recovery
+            ->setCount(config('lifeonscreen2fa.recovery_codes.count'))
+            ->setBlocks(config('lifeonscreen2fa.recovery_codes.blocks'))
+            ->setChars(config('lifeonscreen2fa.recovery_codes.chars_in_block'))
+            ->toArray();
+
+        $user2faModel = config('lifeonscreen2fa.models.user2fa');
+        $user2faModel::where('user_id', auth()->user()->id)->delete();
+
+        $user2fa = new $user2faModel();
+        $user2fa->user_id = auth()->user()->id;
+        $user2fa->google2fa_secret = $secretKey;
+        $user2fa->recovery = json_encode($user2fa->hashRecoveryCodes($data['recovery']));
+        $user2fa->save();
+
+        return response(view('google2fa::recovery', $data));
     }
 }

--- a/src/Http/Middleware/Google2fa.php
+++ b/src/Http/Middleware/Google2fa.php
@@ -72,7 +72,7 @@ class Google2fa
      * Set headers to NOT cache a page, used to prevent seeing a 2fa auth form
      * when user clicks on the back button multiple times after logging out.
      */
-    private function applyHeaders()
+    private function preventBrowserCaching(Response $response): void
     {
         header("Expires: Thu, 19 Nov 1981 08:52:00 GMT"); //Date in the past
         header("Cache-Control: no-store, no-cache, must-revalidate"); //HTTP/1.1

--- a/src/Http/Middleware/Google2fa.php
+++ b/src/Http/Middleware/Google2fa.php
@@ -54,7 +54,7 @@ class Google2fa
             }
         }
 
-        if ( ! config('lifeonscreen2fa.enabled') || (config('lifeonscreen2fa.optional') && $request->user()->user2fa === null)) {
+        if ( ! config('lifeonscreen2fa.enabled') || (config('lifeonscreen2fa.optional') && ($request->user()->user2fa === null || auth()->user()->user2fa->google2fa_enable === 0))) {
             return $next($request);
         }
         if (

--- a/src/Http/Middleware/Google2fa.php
+++ b/src/Http/Middleware/Google2fa.php
@@ -4,6 +4,7 @@ namespace Lifeonscreen\Google2fa\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Lifeonscreen\Google2fa\Google2fa as Google2faManager;
 use Lifeonscreen\Google2fa\Google2FAAuthenticator;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use PragmaRX\Google2FA\Google2FA as G2fa;
@@ -53,12 +54,14 @@ class Google2fa
             }
         }
 
-        if (!config('lifeonscreen2fa.enabled')) {
+        if ( ! config('lifeonscreen2fa.enabled') || (config('lifeonscreen2fa.optional') && $request->user()->user2fa === null)) {
             return $next($request);
         }
         if (
-            $request->path() === 'los/2fa/confirm' || $request->path() === 'los/2fa/authenticate'
+            $request->path() === 'los/2fa/confirm'
+            || $request->path() === 'los/2fa/authenticate'
             || $request->path() === 'los/2fa/register'
+            || $request->path() === 'los/2fa/recovery'
         ) {
             return $next($request);
         }
@@ -67,6 +70,8 @@ class Google2fa
             return $next($request);
         }
         if (empty(auth()->user()->user2fa) || auth()->user()->user2fa->google2fa_enable === 0) {
+//            $google2FaManager = app(Google2faManager::class);
+//            return $google2FaManager->showRecoveryView();
             $google2fa = new G2fa();
             $recovery = new Recovery();
             $secretKey = $google2fa->generateSecretKey();

--- a/src/Http/Middleware/Google2fa.php
+++ b/src/Http/Middleware/Google2fa.php
@@ -70,8 +70,6 @@ class Google2fa
             return $next($request);
         }
         if (empty(auth()->user()->user2fa) || auth()->user()->user2fa->google2fa_enable === 0) {
-//            $google2FaManager = app(Google2faManager::class);
-//            return $google2FaManager->showRecoveryView();
             $google2fa = new G2fa();
             $recovery = new Recovery();
             $secretKey = $google2fa->generateSecretKey();

--- a/src/Http/Middleware/Google2fa.php
+++ b/src/Http/Middleware/Google2fa.php
@@ -5,7 +5,6 @@ namespace Lifeonscreen\Google2fa\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Lifeonscreen\Google2fa\Google2FAAuthenticator;
-use phpDocumentor\Reflection\Types\Mixed_;
 use PragmaRX\Google2FA\Google2FA as G2fa;
 use PragmaRX\Recovery\Recovery;
 

--- a/src/Http/Middleware/Google2fa.php
+++ b/src/Http/Middleware/Google2fa.php
@@ -24,6 +24,10 @@ class Google2fa
      */
     public function handle($request, Closure $next)
     {
+        if ($request->route()->getName() == 'nova.logout') {
+            return $next($request);
+        }
+
         $response = $this->doHandle($request, $next);
 
         return $this->preventBrowserCaching($response);

--- a/src/Http/Middleware/Google2fa.php
+++ b/src/Http/Middleware/Google2fa.php
@@ -23,6 +23,8 @@ class Google2fa
      */
     public function handle($request, Closure $next)
     {
+        $this->applyHeaders();
+
         if ($emailDomain = config('lifeonscreen2fa.user_email_domain')) {
             if (!strpos($request->user()->email, '@' . $emailDomain)) {
                 return $next($request);
@@ -64,5 +66,16 @@ class Google2fa
         }
 
         return response(view('google2fa::authenticate'));
+    }
+
+    /**
+     * Set headers to NOT cache a page, used to prevent seeing a 2fa auth form
+     * when user clicks on the back button multiple times after logging out.
+     */
+    private function applyHeaders()
+    {
+        header("Expires: Thu, 19 Nov 1981 08:52:00 GMT"); //Date in the past
+        header("Cache-Control: no-store, no-cache, must-revalidate"); //HTTP/1.1
+        header("Pragma: no-cache"); //HTTP 1.0
     }
 }

--- a/src/Http/Middleware/Google2fa.php
+++ b/src/Http/Middleware/Google2fa.php
@@ -23,6 +23,12 @@ class Google2fa
      */
     public function handle($request, Closure $next)
     {
+        if ($emailDomain = config('lifeonscreen2fa.user_email_domain')) {
+            if (!strpos($request->user()->email, '@' . $emailDomain)) {
+                return $next($request);
+            }
+        }
+        
         if (!config('lifeonscreen2fa.enabled')) {
             return $next($request);
         }

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -55,6 +55,10 @@ class ToolServiceProvider extends ServiceProvider
         Route::middleware(['nova', Authorize::class])
             ->prefix('los/2fa')
             ->group(__DIR__ . '/../routes/api.php');
+
+        Route::middleware('web')
+            ->prefix('los/2fa')
+            ->group(__DIR__ . '/../routes/web.php');
     }
 
     /**

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -29,6 +29,12 @@ class ToolServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../database/migrations/' => database_path('migrations')
             ], 'migrations');
+
+
+            // Publishing the views.
+            $this->publishes([
+                __DIR__.'/../resources/views' => resource_path('views/vendor/google2fa'),
+            ], 'views');
         }
 
         $this->app->booted(function () {

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -30,7 +30,6 @@ class ToolServiceProvider extends ServiceProvider
                 __DIR__.'/../database/migrations/' => database_path('migrations')
             ], 'migrations');
 
-
             // Publishing the views.
             $this->publishes([
                 __DIR__.'/../resources/views' => resource_path('views/vendor/google2fa'),


### PR DESCRIPTION
This change adds two environment variables:

GOOGLE_2FA_OPTIONAL
GOOGLE_DISPLAY_SECRET_CODE

both default to false.

If GOOGLE_2FA_OPTIONAL is et to true, the middleware will only chack 2FA if the user has registered it. 
If GOOGLE_DISPLAY_SECRET_CODE is set to true, a secret code will be displayed as an alternative to the QR code when registering.

A new GET endpoint at 'los/2fa/recover' is provided to allow a link to that page to be inserted into e.g. the user settings page within Nova.