### PR TITLE
update pragmarx/recovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": ">=7.1.0",
         "bacon/bacon-qr-code": "^2.0",
-        "pragmarx/recovery": "^0.1.0",
+        "pragmarx/recovery": "^0.2.1",
         "pragmarx/google2fa-laravel": "^0.2.0"
     },
     "autoload": {


### PR DESCRIPTION
The version of  recovery package is doesn't support above of php7. Just updated the last version.